### PR TITLE
Run method now wrapped in try-except clause

### DIFF
--- a/myentity/__init__.py
+++ b/myentity/__init__.py
@@ -70,9 +70,6 @@ class myentity(thesdk):
         '''Guideline: Define model depencies of executions in `run` method.
 
         '''
-        if len(arg)>0:
-            self.par=True      #flag for parallel processing
-            self.queue=arg[0]  #multiprocessing.queue as the first argument
         if self.model=='py':
             self.main()
 

--- a/myentity/__init__.py
+++ b/myentity/__init__.py
@@ -25,6 +25,7 @@ if not (os.path.abspath('../../thesdk') in sys.path):
 
 from thesdk import *
 
+import traceback
 import numpy as np
 
 class myentity(thesdk):
@@ -70,8 +71,15 @@ class myentity(thesdk):
         '''Guideline: Define model depencies of executions in `run` method.
 
         '''
-        if self.model=='py':
-            self.main()
+        try:
+            if self.model=='py':
+                self.main()
+        except:
+            if self.par:
+                self.queue.put({**self.IOS.Members, **self.extracts.Members})
+            self.print_log(type='W', msg='Something went wrong with running the simulation')
+            self.print_log(type='W', msg=traceback.format_exc())
+
 
 if __name__=="__main__":
     import argparse


### PR DESCRIPTION
If run crashes during run_parallel, the execution hangs indefinitely since nothing is put into self.queue.


@mkosunen Ok to merge if CI/CD procedure in thesdk_template is successful?