### PR TITLE
Retry: Run method now wrapped in try-expect clause

### DIFF
--- a/myentity/__init__.py
+++ b/myentity/__init__.py
@@ -70,9 +70,6 @@ class myentity(thesdk):
         '''Guideline: Define model depencies of executions in `run` method.
 
         '''
-        if len(arg)>0:
-            self.par=True      #flag for parallel processing
-            self.queue=arg[0]  #multiprocessing.queue as the first argument
         if self.model=='py':
             self.main()
 

--- a/myentity/__init__.py
+++ b/myentity/__init__.py
@@ -25,6 +25,7 @@ if not (os.path.abspath('../../thesdk') in sys.path):
 
 from thesdk import *
 
+import traceback
 import numpy as np
 
 class myentity(thesdk):
@@ -70,8 +71,15 @@ class myentity(thesdk):
         '''Guideline: Define model depencies of executions in `run` method.
 
         '''
-        if self.model=='py':
-            self.main()
+        try:
+            if self.model=='py':
+                self.main()
+        except:
+            if self.par:
+                self.queue.put({**self.IOS.Members, **self.extracts.Members})
+            self.print_log(type='W', msg='Something went wrong with running the simulation')
+            self.print_log(type='W', msg=traceback.format_exc())
+
 
 if __name__=="__main__":
     import argparse


### PR DESCRIPTION
This PR revives the formerly closed PR#4. The point is to return something if the parallel thread execution ends in an error.  The errors are not masked by the try-except block, since the stack trace will be printed with self.print_log. I reiterate, that all entities should follow this convention, since threads hanging forever on erronous exit is a serious issue. Hence, I believe this a good place to document this behaviour as this entity is used as template by init_entity.sh. 

